### PR TITLE
fix: Vite should be devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
   "dependencies": {
     "chalk": "4.1.2",
     "magic-string": "^0.26.1",
-    "shell-quote": "^1.7.3",
-    "vite": "^2.8.6"
+    "shell-quote": "^1.7.3"
   },
   "devDependencies": {
     "@vue/compiler-dom": "^3.2.31",
@@ -60,6 +59,7 @@
     "vue": "^3.2.31",
     "vue-template-compiler": "^2.6.14",
     "vue-template-es2015-compiler": "^1.9.1",
-    "zx": "^6.0.6"
+    "zx": "^6.0.6",
+    "vite": "^2.8.6"
   }
 }


### PR DESCRIPTION
vite 在 dependencies 中会造成重复下载，导致 `import { Plugin } from 'vite';` 引用路径不一致，ts 效验出错


> "import("node_modules/vite-plugin-vue-inspector/node_modules/vite/dist/node/index").Plugin" 到类型 "import("node_modules/vite/dist/node/index").Plugin" 的转换可能是错误的，因为两种类型不能充分重叠。如果这是有意的，请先将表达式转换为 "unknown"
