### PR TITLE
fix: normalize deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "vite": "^2.0.0"
   },
   "dependencies": {
+    "@vue/compiler-dom": "^3.2.31",
+    "@vue/component-compiler-utils": "^3.3.0",
     "chalk": "4.1.2",
     "magic-string": "^0.26.1",
     "shell-quote": "^1.7.3"
   },
   "devDependencies": {
-    "@vue/compiler-dom": "^3.2.31",
     "@vue/compiler-sfc": "^3.2.31",
-    "@vue/component-compiler-utils": "^3.3.0",
     "@webfansplz/eslint-config": "^0.1.0",
     "eslint": "^8.11.0",
     "esmo": "^0.14.1",


### PR DESCRIPTION
`@vue/compiler-dom` 包有实际代码引入，但是存放在 devDependencies 被打包进主体代码，识别打包环境为浏览器

[compiler-dom](https://github.com/vuejs/core/blob/1070f127a78bfe7da6fe550cc272ef11a1f434a0/packages/compiler-dom/src/parserOptions.ts#L29)

node 使用查找不到 [document](https://github.com/vuejs/core/blob/1070f127a78bfe7da6fe550cc272ef11a1f434a0/packages/compiler-dom/src/decodeHtmlBrowser.ts#L7)，[parse](https://github.com/webfansplz/vite-plugin-vue-inspector/blob/513657c7389b91d2f960a6ada13b25cd40afec58/src/compiler/template.ts#L4) 报错

