### PR TITLE
fix(launch-editor): ignore output to stderr

### DIFF
--- a/src/launch-editor.ts
+++ b/src/launch-editor.ts
@@ -200,7 +200,9 @@ function guessEditor() {
   // `Get-Process` on Windows
   try {
     if (process.platform === "darwin") {
-      const output = child_process.execSync("ps x").toString()
+      const output = child_process
+        .execSync("ps x", { stdio: ["pipe", "pipe", "ignore"] })
+        .toString()
       const processNames = Object.keys(COMMON_EDITORS_OSX)
       for (let i = 0; i < processNames.length; i++) {
         const processName = processNames[i]
@@ -214,6 +216,7 @@ function guessEditor() {
       const output = child_process
         .execSync(
           "wmic process where \"executablepath is not null\" get executablepath",
+          { stdio: ["pipe", "pipe", "ignore"] },
         )
         .toString()
       const runningProcesses = output.split("\r\n")
@@ -229,7 +232,9 @@ function guessEditor() {
       // x List all processes owned by you
       // -o comm Need only names column
       const output = child_process
-        .execSync("ps x --no-heading -o comm --sort=comm")
+        .execSync(
+          "ps x --no-heading -o comm --sort=comm",
+          { stdio: ["pipe", "pipe", "ignore"] })
         .toString()
       const processNames = Object.keys(COMMON_EDITORS_LINUX)
       for (let i = 0; i < processNames.length; i++) {


### PR DESCRIPTION
Hi @webfansplz 👋 !

I love this plugin, and also the fact that you can just click a button to crack open a StackBlitz 🔥 !

However, I was a bit annoyed by the output it rendered on StackBlitz when clicking a component

![image](https://user-images.githubusercontent.com/1913805/168779232-816fe096-ceb6-438b-81a7-b041a440ac85.png)

The reason is that the `ps` command does not exist (yet) on StackBlitz and thus renders `jsh: command not found: ps` on the stderr stream. Because we're only interested in what's being rendered on `stdout`, we can ignore that stream.

I've sent the same PR to the `launch-editor` package https://github.com/yyx990803/launch-editor/pull/41.

I'm pretty sure the changes should be ok, although I can't test what's being rendered on Windows but I did notice that the `launch-editor` also ignores stderr for Windows. However, they seem to be using a powershell command.

-------------------------------
We can make opening a file on StackBlitz even faster. But that's entirely your call if you want to add this code block or not. But by adding this at the top of `guessEditor()`, will make opening the file noticeably faster.

```js
if (process.versions.webcontainer) {
    return [process.env.EDITOR];
}
```

The reason is that spawning the `ps` command takes a bit of compute while we already know it's going to fail. You can compare the project with [this project](https://stackblitz.com/edit/vitejs-vite-23hgnr?file=.stackblitzrc&terminal=dev) where I've used the `VUE_EDITOR` environment variable.

Kind regards
Sam