### PR TITLE
feat(launch-editor): add short path for WebContainer

### DIFF
--- a/src/launch-editor.ts
+++ b/src/launch-editor.ts
@@ -191,7 +191,11 @@ function getArgumentsForLineNumber(
 }
 
 function guessEditor() {
-  // Explicit config always wins
+  // WebContainer config always wins
+  if (process.versions.webcontainer)
+    return [process.env.EDITOR || "code"]
+
+  // Explicit config always wins in non-WebContainer environments
   if (process.env.VUE_EDITOR)
     return shellQuote.parse(process.env.VUE_EDITOR)
 


### PR DESCRIPTION
Small PR to improve performance on StackBlitz WebContainer. Currently when clicking a component you notice a small delay (~0.5 - 1s is my gutfeeling) because it spins up the `ps` command. With this short path it feels quite instant.