### PR TITLE
feat: normalize request url

### DIFF
--- a/src/Overlay.vue
+++ b/src/Overlay.vue
@@ -39,6 +39,12 @@
 <script>
 import inspectorOptions from "virtual:vue-inspector-options"
 
+const importMetaUrl = new URL(import.meta.url)
+const protocol = inspectorOptions.serverOptions?.https ? "https:" : importMetaUrl.protocol
+const host = inspectorOptions.serverOptions?.host ?? importMetaUrl.hostname
+const port = inspectorOptions.serverOptions?.port ?? importMetaUrl.port
+const baseUrl = `${protocol}//${host}:${port}`
+
 export default {
   data() {
     return {
@@ -160,7 +166,10 @@ export default {
       const { file, line, column } = params
       this.overlayVisible = false
       fetch(
-        `/__open-stack-frame-in-editor?file=${file}&line=${line}&column=${column}`,
+        `${baseUrl}/__open-stack-frame-in-editor?file=${file}&line=${line}&column=${column}`,
+        {
+          mode: "no-cors",
+        },
       )
     },
     onMouseMove(e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import path from "path"
 import { fileURLToPath } from "url"
 import fs from "fs"
 import { yellow, red } from "kolorist"
-import { normalizePath } from "vite"
+import { normalizePath, ServerOptions } from "vite"
 import type { PluginOption } from "vite"
 import { compileSFCTemplate } from "./compiler"
 import { parseVueRequest } from "./utils"
@@ -70,6 +70,8 @@ const DEFAULT_INSPECTOR_OPTIONS: VitePluginInspectorOptions = {
 function VitePluginInspector(options: VitePluginInspectorOptions = DEFAULT_INSPECTOR_OPTIONS): PluginOption {
   const inspectorPath = getInspectorPath()
   const normalizedOptions = { ...DEFAULT_INSPECTOR_OPTIONS, ...options }
+  let serverOptions: ServerOptions | undefined
+
   return {
     name: "vite-plugin-vue-inspector",
     enforce: "pre",
@@ -89,7 +91,7 @@ function VitePluginInspector(options: VitePluginInspectorOptions = DEFAULT_INSPE
 
     async load(id) {
       if (id === "virtual:vue-inspector-options") {
-        return `export default ${JSON.stringify(normalizedOptions)}`
+        return `export default ${JSON.stringify({ ...normalizedOptions, serverOptions })}`
       }
       else if (id.startsWith(inspectorPath)) {
         const { query } = parseVueRequest(id)
@@ -137,6 +139,9 @@ function VitePluginInspector(options: VitePluginInspectorOptions = DEFAULT_INSPE
           },
         ],
       }
+    },
+    configResolved(resolvedConfig) {
+      serverOptions = resolvedConfig.server
     },
   }
 }


### PR DESCRIPTION
Fixed to work even if the vite server port is changed.
I use [Vite Ruby](https://vite-ruby.netlify.app/).