### PR TITLE
support reverse proxies

### DIFF
--- a/src/Overlay.vue
+++ b/src/Overlay.vue
@@ -40,12 +40,14 @@
 import inspectorOptions from "virtual:vue-inspector-options"
 
 const isClient = typeof window !== "undefined"
-const importMetaUrl = isClient ? new URL(import.meta.url) : {}
-const protocol = inspectorOptions.serverOptions?.https ? "https:" : importMetaUrl?.protocol
-const hostOpts = inspectorOptions.serverOptions?.host
-const host = hostOpts && hostOpts !== true ? hostOpts : importMetaUrl?.hostname
-const port = inspectorOptions.serverOptions?.port ?? importMetaUrl?.port
-const baseUrl = isClient ? `${protocol}//${host}:${port}` : ""
+
+let baseUrl = ""
+
+if(isClient){
+     const importMetaUrl = new URL(import.meta.url)
+     baseUrl = `${importMetaUrl.protocol}//${importMetaUrl.hostname}:${importMetaUrl.port}`
+}
+
 
 export default {
   data() {


### PR DESCRIPTION
hi, we really liked your plugin and wanted do use it in our setup.

We are using [devspace](https://www.devspace.sh/) for development, which we use to setup a reverse-proxy and development container with our application.

The application container is running under port 80 (http) and on localhost.
vite.config.ts:
``` js
    server: {
        host: true,
        port: 80,
        open: 'https://mengencloud.swp.localhost:8443',
    },
```
The nginx reverse proxy is running on `https://mengencloud.swp.localhost:8443`

This leads to the following error:
![image](https://user-images.githubusercontent.com/64835150/195306448-eb997bd8-03d6-4335-9946-14fdd1ac6d30.png)

The inspector uses the (wrong) port from the vite.config.ts and not from `import.meta.url`.

This pull-request uses the `import.meta.url` in a browser-context and ignores any other urls from vite.
Which works for us, but leads maybe to problems in other use-cases.

We would like to know how a fix like this could be integrated into vite-plugin-vue-inspector.

