### PR TITLE
fix: hide injected app in Vue devtools

### DIFF
--- a/packages/core/src/load.js
+++ b/packages/core/src/load.js
@@ -23,9 +23,17 @@ function load() {
   const { vue } = inspectorOptions
   // vue 2/3 compatibility
   vue === 3
-    ? Vue.createApp(App).mount(`#${CONTAINER_ID}`)
+    ? Vue.createApp({
+      render: () => Vue.h(App),
+      devtools: {
+        hide: true,
+      },
+    }).mount(`#${CONTAINER_ID}`)
     : new Vue.default({
       render: h => h(App),
+      devtools: {
+        hide: true,
+      },
     }).$mount(`#${CONTAINER_ID}`)
 }
 


### PR DESCRIPTION
Fixes #56 