### PR TITLE
fix: normalize path in `data-v-inspector` attribute

### DIFF
--- a/packages/core/src/compiler/template.ts
+++ b/packages/core/src/compiler/template.ts
@@ -6,6 +6,7 @@ import vueJsxPlugin from '@vue/babel-plugin-jsx'
 import typescriptPlugin from '@babel/plugin-transform-typescript'
 import importMeta from '@babel/plugin-syntax-import-meta'
 import { parseJSXIdentifier } from '../utils'
+import { normalizePath } from 'vite'
 
 const EXCLUDE_TAG = ['template', 'script', 'style']
 const KEY_DATA = 'data-v-inspector'
@@ -19,7 +20,7 @@ export async function compileSFCTemplate(
   { code, id, type }: CompileSFCTemplateOptions,
 ) {
   const s = new MagicString(code)
-  const relativePath = path.relative(process.cwd(), id)
+  const relativePath = normalizePath(path.relative(process.cwd(), id))
   const result = await new Promise((resolve) => {
     switch (type) {
       case 'template': {


### PR DESCRIPTION
Fixes the error `SyntaxError: Invalid Unicode escape sequence` I had, caused by this line:
```ts
"data-v-inspector": "src\modules\common\composables\asyncSearch\useAsyncSearch.tsx:69:12"
```
Will now be generated as
```ts
"data-v-inspector": "src/modules/common/composables/asyncSearch/useAsyncSearch.tsx:69:12"
```