### PR TITLE
fix: respect `server.port` when setting custom host

### DIFF
--- a/packages/core/src/Overlay.vue
+++ b/packages/core/src/Overlay.vue
@@ -5,7 +5,7 @@ const importMetaUrl = isClient ? new URL(import.meta.url) : {}
 const protocol = inspectorOptions.serverOptions?.https ? 'https:' : importMetaUrl?.protocol
 const hostOpts = inspectorOptions.serverOptions?.host
 const host = hostOpts && hostOpts !== true ? hostOpts : importMetaUrl?.hostname
-const port = inspectorOptions.serverOptions?.port ?? importMetaUrl?.port
+const port = hostOpts && hostOpts !== true ? inspectorOptions.serverOptions?.port : importMetaUrl?.port
 const baseUrl = isClient ? inspectorOptions.openInEditorHost || `${protocol}//${host}:${port}` : ''
 
 const KEY_DATA = 'data-v-inspector'


### PR DESCRIPTION
I have caddy being a https proxy so that I can develop across the lan (ie to mobile phone)

When I use the overlay to go to the code it is choosing the default port (in my case 3333) rather than the proxied port (in my case empty).

This pull request sets the port from the serverOptions only if the host has been defined.

Tested via http://localhost:3333 and http://10.1.1.95:3333 (my internal lan ip) and https://mydev.mydomain.com