### PR TITLE
feat: introducing `disableInspectorOnEditorOpen` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ interface VitePluginInspectorOptions {
   * @default false
   */
   openInEditorHost?: string | false
+
+  /**
+   * disable inspector on editor open
+   * @default false
+   */
+  disableInspectorOnEditorOpen?: boolean
 }
 ```
 

--- a/packages/core/src/Overlay.vue
+++ b/packages/core/src/Overlay.vue
@@ -19,7 +19,7 @@ export default {
       floatsRef: null,
       enabled: inspectorOptions.enabled,
       toggleCombo: inspectorOptions.toggleComboKey?.toLowerCase?.()?.split?.('-') ?? false,
-      closeWhenEditorOpen: inspectorOptions.closeWhenEditorOpen,
+      disableInspectorOnEditorOpen: inspectorOptions.disableInspectorOnEditorOpen,
       overlayVisible: false,
       position: {
         x: 0,
@@ -218,7 +218,7 @@ export default {
         },
       )
 
-      if (this.closeWhenEditorOpen)
+      if (this.disableInspectorOnEditorOpen)
         promise.then(this.disable)
 
       return promise

--- a/packages/core/src/Overlay.vue
+++ b/packages/core/src/Overlay.vue
@@ -19,6 +19,7 @@ export default {
       floatsRef: null,
       enabled: inspectorOptions.enabled,
       toggleCombo: inspectorOptions.toggleComboKey?.toLowerCase?.()?.split?.('-') ?? false,
+      closeWhenEditorOpen: inspectorOptions.closeWhenEditorOpen,
       overlayVisible: false,
       position: {
         x: 0,
@@ -210,12 +211,17 @@ export default {
        * Vite built-in support
        * https://github.com/vitejs/vite/blob/d59e1acc2efc0307488364e9f2fad528ec57f204/packages/vite/src/node/server/index.ts#L569-L570
        * */
-      return fetch(
+      const promise = fetch(
         `${baseUrl}/__open-in-editor?file=${file}:${line}:${column}`,
         {
           mode: 'no-cors',
         },
       )
+
+      if (this.closeWhenEditorOpen)
+        promise.then(this.disable)
+
+      return promise
     },
     onUpdated() {
       // to be replaced programmatically

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,10 +84,10 @@ export interface VitePluginInspectorOptions {
   lazyLoad?: number | false
 
   /**
-   * close inspector when editor open
+   * disable inspector on editor open
    * @default false
    */
-  closeWhenEditorOpen?: boolean
+  disableInspectorOnEditorOpen?: boolean
 }
 
 const toggleComboKeysMap = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,12 @@ export interface VitePluginInspectorOptions {
    * @default false
   */
   lazyLoad?: number | false
+
+  /**
+   * close inspector when editor open
+   * @default false
+   */
+  closeWhenEditorOpen?: boolean
 }
 
 const toggleComboKeysMap = {


### PR DESCRIPTION
close #73

I'm not sure if this name that `closeWhenEditorOpen` adequately expresses its function, and I'd love to hear your suggestions.