### PR TITLE
fix(core): ignore user babel config on compile

### DIFF
--- a/packages/core/src/compiler/template.ts
+++ b/packages/core/src/compiler/template.ts
@@ -55,6 +55,7 @@ export async function compileSFCTemplate(
       case 'jsx': {
         const ast = babelParse(code, {
           babelrc: false,
+          configFile: false,
           comments: true,
           plugins: [
             importMeta,


### PR DESCRIPTION
Project with babel.config.js file, which output error

maybe we should also ignore babel.config.js file