### PR TITLE
fix: `openInEditor` types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,7 @@ export interface VueInspectorClient {
   enable: () => void
   disable: () => void
   toggleEnabled: () => void
-  openInEditor: (baseUrl: string, file: string, line: number, column: number) => void
+  openInEditor: (url: URL) => void
   onUpdated: () => void
 }
 


### PR DESCRIPTION
https://github.com/webfansplz/vite-plugin-vue-inspector/commit/738b7818b79059777ae12fb987273be15a9d8aa6