### PR TITLE
feat: respect user `process.env.LAUNCH_EDITOR` setting

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -132,7 +132,7 @@ export const DEFAULT_INSPECTOR_OPTIONS: VitePluginInspectorOptions = {
   toggleButtonPos: 'top-right',
   appendTo: '',
   lazyLoad: false,
-  launchEditor: 'code',
+  launchEditor: process.env.LAUNCH_EDITOR ?? 'code',
 } as const
 
 const availableLaunchEditors = [


### PR DESCRIPTION
Use `process.env.LAUNCH_EDITOR` by default for the `launchEditor` option if set, and only default to `'code'` if nothing is set in the env.

Resolves https://github.com/webfansplz/vite-plugin-vue-inspector/issues/92
