### PR TITLE
fix: allow arbitrary string for launchEditor type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,7 +109,7 @@ export interface VitePluginInspectorOptions {
    *
    * @default code (Visual Studio Code)
    */
-  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm'
+  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | string
 }
 
 const toggleComboKeysMap = {


### PR DESCRIPTION
Currently, the `launchEditor` only allows a specific set of strings for known IDEs. However,  the `LAUNCH_EDITOR` env [can actually be an arbitrary string](https://github.com/vuejs/devtools-next/pull/401). This is used when the editor is in a non-default location, or another tool/editor/script should be launched. 

This PR allows a string as a type, which should be valid.

This type change is blocking downstream fixes for Vue Devtools Next - https://github.com/vuejs/devtools-next/pull/401
