### PR TITLE
feat: exclude template tag to support jsx-directive

### DIFF
--- a/packages/core/src/compiler/template.ts
+++ b/packages/core/src/compiler/template.ts
@@ -77,7 +77,7 @@ export async function compileSFCTemplate(
 
         babelTraverse(ast, {
           enter({ node }) {
-            if (node.type === 'JSXElement') {
+            if (node.type === 'JSXElement' && !EXCLUDE_TAG.includes(s.slice(node.openingElement.name.start, node.openingElement.name.end))) {
               if (node.openingElement.attributes.some(attr => attr.type !== 'JSXSpreadAttribute' && attr.name.name === KEY_DATA,
               ))
                 return

--- a/packages/playground/vue3/src/Welcome.tsx
+++ b/packages/playground/vue3/src/Welcome.tsx
@@ -4,6 +4,11 @@ export default defineComponent({
   name: 'Welcome',
   setup() {
     const text = 'Welcome to here 🚀 .'
-    return () => <p style={{ color: '#fcb80f', cursor: 'pointer' }}> {text} </p>
+    return () => (
+      <p style={{ color: '#fcb80f', cursor: 'pointer' }}>
+        {text}
+        <template v-if={text}>{text}</template>
+      </p>
+    )
   },
 })


### PR DESCRIPTION
In jsx-directive I will conver `<template v-if={true}>` to `true ? <>`, 
But after use `vite-plugin-vue-inspector` , the `true ? < data-v-inspector="src/Welcome.tsx:8:6">` is a syntax error