### PR TITLE
docs: fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ if (inspector) {
 
 This project is inspired by [react-dev-inspector](https://github.com/zthxxx/react-dev-inspector) .
 
-Partially implementation is inspired by [vite-plugin-svelte-inspector](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte/src/ui/inspector) .
+Partially implementation is inspired by [vite-plugin-svelte-inspector](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte-inspector) .
 
 ## 🤖️ Analysis of Theory
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -319,7 +319,7 @@ if (inspector) {
 
 This project is inspired by [react-dev-inspector](https://github.com/zthxxx/react-dev-inspector) .
 
-Partially implementation is inspired by [vite-plugin-svelte-inspector](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte/src/ui/inspector) .
+Partially implementation is inspired by [vite-plugin-svelte-inspector](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte-inspector) .
 
 ## 🤖️ Analysis of Theory
 

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -320,7 +320,7 @@ if (inspector) {
 
 This project is inspired by [react-dev-inspector](https://github.com/zthxxx/react-dev-inspector) .
 
-Partially implementation is inspired by [vite-plugin-svelte-inspector](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte/src/ui/inspector) .
+Partially implementation is inspired by [vite-plugin-svelte-inspector](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte-inspector) .
 
 ## 🤖️ Analysis of Theory
 


### PR DESCRIPTION
This PR fixes the incorrect link path for `vite-plugin-svelte-inspector`.