### PR TITLE
feat: codebuddy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ interface VitePluginInspectorOptions {
    *
    * @default code (Visual Studio Code)
    */
-  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | 'cursor'
+  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | 'cursor' | 'buddy' | 'buddycn'
 }
 ```
 
@@ -201,6 +201,8 @@ interface VitePluginInspectorOptions {
 | `visualstudio` | [Visual Studio](https://www.visualstudio.com/vs/) | | |✓|
 | `webstorm` | [WebStorm](https://www.jetbrains.com/webstorm/) |✓|✓|✓|
 | `cursor` | [Cursor](https://www.cursor.com/) |✓|✓|✓|
+| `buddy` | [CodeBuddy](https://www.codebuddy.ai/) |✓|✓|✓|
+| `buddycn` | [CodeBuddy CN](https://copilot.tencent.com/ide/) |✓|✓|✓|
 
 ## 🔌  Configuration IDE / Editor
 
@@ -289,6 +291,28 @@ Yes! you can also use vim if you want, just set env to shell
 ```bash
 export LAUNCH_EDITOR=vim
 ```
+
+<br />
+
+### CodeBuddy CN
+
+- install CodeBuddy CN command line tools (usually automatically installed)
+
+- then set env to shell, like `.bashrc` or `.zshrc`
+
+  ```bash
+  export LAUNCH_EDITOR=buddycn
+  ```
+
+**OR**
+
+- just set env with an absolute path to shell (MacOS example)
+
+  ```bash
+  export LAUNCH_EDITOR='/Users/YOUR_USERNAME/.codebuddy/bin/buddycn'
+  ```
+
+> Note: Replace `YOUR_USERNAME` with your actual username. CodeBuddy CN uses the same `-g file:line:column` syntax as VS Code.
 
 <br />
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -168,7 +168,7 @@ interface VitePluginInspectorOptions {
    *
    * @default code (Visual Studio Code)
    */
-  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | 'cursor'
+  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | 'cursor' | 'buddy' | 'buddycn'
 }
 ```
 
@@ -201,6 +201,8 @@ interface VitePluginInspectorOptions {
 | `visualstudio` | [Visual Studio](https://www.visualstudio.com/vs/) | | |✓|
 | `webstorm` | [WebStorm](https://www.jetbrains.com/webstorm/) |✓|✓|✓|
 | `cursor` | [Cursor](https://www.cursor.com/) |✓|✓|✓|
+| `buddy` | [CodeBuddy](https://www.codebuddy.ai/) |✓|✓|✓|
+| `buddycn` | [CodeBuddy CN](https://copilot.tencent.com/ide/) |✓|✓|✓|
 
 ## 🔌  Configuration IDE / Editor
 
@@ -289,6 +291,28 @@ Yes! you can also use vim if you want, just set env to shell
 ```bash
 export LAUNCH_EDITOR=vim
 ```
+
+<br />
+
+### CodeBuddy CN
+
+- install CodeBuddy CN command line tools (usually automatically installed)
+
+- then set env to shell, like `.bashrc` or `.zshrc`
+
+  ```bash
+  export LAUNCH_EDITOR=buddycn
+  ```
+
+**OR**
+
+- just set env with an absolute path to shell (MacOS example)
+
+  ```bash
+  export LAUNCH_EDITOR='/Users/YOUR_USERNAME/.codebuddy/bin/buddycn'
+  ```
+
+> Note: Replace `YOUR_USERNAME` with your actual username. CodeBuddy CN uses the same `-g file:line:column` syntax as VS Code.
 
 <br />
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,7 +109,7 @@ export interface VitePluginInspectorOptions {
    *
    * @default process.env.LAUNCH_EDITOR ?? code (Visual Studio Code)
    */
-  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | 'rider' | 'cursor' | string
+  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | 'rider' | 'cursor' | 'buddy' | 'buddycn' | string
 
   /**
    * Disable animation/transition, will auto disable when `prefers-reduced-motion` is set

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -168,7 +168,7 @@ interface VitePluginInspectorOptions {
    *
    * @default code (Visual Studio Code)
    */
-  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | 'cursor'
+  launchEditor?: 'appcode' | 'atom' | 'atom-beta' | 'brackets' | 'clion' | 'code' | 'code-insiders' | 'codium' | 'emacs' | 'idea' | 'notepad++' | 'pycharm' | 'phpstorm' | 'rubymine' | 'sublime' | 'vim' | 'visualstudio' | 'webstorm' | 'cursor' | 'buddy' | 'buddycn'
 }
 ```
 
@@ -201,6 +201,8 @@ interface VitePluginInspectorOptions {
 | `visualstudio` | [Visual Studio](https://www.visualstudio.com/vs/) | | |✓|
 | `webstorm` | [WebStorm](https://www.jetbrains.com/webstorm/) |✓|✓|✓|
 | `cursor` | [Cursor](https://www.cursor.com/) |✓|✓|✓|
+| `buddy` | [CodeBuddy](https://www.codebuddy.ai/) |✓|✓|✓|
+| `buddycn` | [CodeBuddy CN](https://copilot.tencent.com/ide/) |✓|✓|✓|
 
 
 ## 🔌  Configuration IDE / Editor
@@ -290,6 +292,28 @@ Yes! you can also use vim if you want, just set env to shell
 ```bash
 export LAUNCH_EDITOR=vim
 ```
+
+<br />
+
+### CodeBuddy CN
+
+- install CodeBuddy CN command line tools (usually automatically installed)
+
+- then set env to shell, like `.bashrc` or `.zshrc`
+
+  ```bash
+  export LAUNCH_EDITOR=buddycn
+  ```
+
+**OR**
+
+- just set env with an absolute path to shell (MacOS example)
+
+  ```bash
+  export LAUNCH_EDITOR='/Users/YOUR_USERNAME/.codebuddy/bin/buddycn'
+  ```
+
+> Note: Replace `YOUR_USERNAME` with your actual username. CodeBuddy CN uses the same `-g file:line:column` syntax as VS Code.
 
 <br />
 


### PR DESCRIPTION
# Add Support for CodeBuddy (buddy/buddycn) Editor

## 📋 Summary

This PR adds native support for [CodeBuddy](https://www.codebuddy.ai/) editor (commands: `buddy` and `buddycn`) to the `launchEditor` configuration option.

## 🎯 Motivation

CodeBuddy is an AI-powered code editor developed by Tencent that uses the same CLI syntax as VS Code for opening files with line and column positioning. Currently, users need to create custom wrapper scripts to use CodeBuddy with this plugin. This PR simplifies the setup by adding first-class support for both `buddy` and `buddycn` commands.

## 🔧 Changes

### 1. Type Definitions
- Added `'buddy'` and `'buddycn'` to the `launchEditor` option type in:
  - `packages/core/src/index.ts`
  - All README files (root, packages/core, packages/unplugin)

### 2. Documentation
- Added CodeBuddy/CodeBuddy CN to the supported editors table
- Added configuration examples for CodeBuddy CN in all README files
- Included both environment variable and direct configuration methods

## 💡 Editor Compatibility

CodeBuddy uses the same command-line interface as VS Code:

```bash
buddycn -g <file:line[:character]>
```

**Key CLI option:**
- `-g --goto <file:line[:character]>`: Open a file at the path on the specified line and character position

This makes CodeBuddy fully compatible with the existing `launch-editor` infrastructure without requiring any additional code changes beyond type definitions.

## 📦 Usage Examples

### Method 1: Direct Configuration (Recommended)
```typescript
import VueInspector from 'vite-plugin-vue-inspector'

export default defineConfig({
  plugins: [
    vue(),
    VueInspector({
      toggleComboKey: 'meta',
      launchEditor: 'buddycn', // ✅ Now officially supported!
    }),
  ],
})
```

### Method 2: Environment Variable
```bash
# In shell configuration (.bashrc, .zshrc, etc.)
export LAUNCH_EDITOR=buddycn

# Or in package.json
{
  "scripts": {
    "dev": "LAUNCH_EDITOR=buddycn vite"
  }
}
```

## ✅ Testing

- [x] TypeScript types compile without errors
- [x] Documentation updated in all README files
- [x] Verified CLI syntax compatibility with VS Code
- [x] Tested with CodeBuddy CN 1.2.9

## 🔗 References

- **Official Website (International)**: https://www.codebuddy.ai/
- **Official Website (China)**: https://copilot.tencent.com/ide/
- **Editor Commands**: `buddy` (international version), `buddycn` (China version)
- **CLI Syntax**: Compatible with VS Code (`-g file:line:column`)
- **Supported Platforms**: Linux ✓ | Windows ✓ | macOS ✓

## 📝 Additional Notes

CodeBuddy is available in two variants:
1. **`buddy`**: International version - https://www.codebuddy.ai/
2. **`buddycn`**: China localized version (CodeBuddy CN / Tencent Copilot IDE) - https://copilot.tencent.com/ide/

Both use identical CLI syntax and can be configured interchangeably based on the user's installed version.

---

This change improves developer experience by eliminating the need for custom wrapper scripts when using CodeBuddy editor with this plugin.
