### PR TITLE
feat: support Vite 8 bundledDev mode for virtual modules

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -209,7 +209,7 @@ function VitePluginInspector(options: VitePluginInspectorOptions = DEFAULT_INSPE
           return
 
         if ((typeof appendTo === 'string' && filename.endsWith(appendTo))
-          || (appendTo instanceof RegExp && appendTo.test(filename)))
+          || (appendTo instanceof RegExp && (appendTo.lastIndex = 0, appendTo.test(filename))))
           return { code: `${code}\nimport 'virtual:vue-inspector-path:load.js'` }
       },
       configureServer(server) {
@@ -222,22 +222,23 @@ function VitePluginInspector(options: VitePluginInspectorOptions = DEFAULT_INSPE
           console.log(`  ${green('➜')}  ${bold('Vue Inspector')}: ${green(`Press ${yellow(keys)} in App to toggle the Inspector`)}\n`)
         })
       },
-      transformIndexHtml(html) {
-        if (appendTo)
-          return
-        return {
-          html,
-          tags: [
-            {
-              tag: 'script',
-              injectTo: 'head',
-              attrs: {
-                type: 'module',
-                src: `${config.base || '/'}@id/virtual:vue-inspector-path:load.js`,
+      transformIndexHtml: {
+        order: 'pre',
+        handler(html) {
+          if (appendTo)
+            return
+          return {
+            html,
+            tags: [
+              {
+                tag: 'script',
+                injectTo: 'head',
+                attrs: { type: 'module' },
+                children: 'import \'virtual:vue-inspector-path:load.js\'',
               },
-            },
-          ],
-        }
+            ],
+          }
+        },
       },
       configResolved(resolvedConfig) {
         config = resolvedConfig


### PR DESCRIPTION
Use an inline import with order:'pre' in transformIndexHtml so Vite's HTML pipeline picks up the inspector module before bundling.

Also, reset appendTo regex lastIndex before test() to prevent skipped matches when a global-flag regex is used.

### Testing

I built and added this to my Vite 8 project using `npm link` to test the plugin code locally. I was able to launch Vue Inspector on my SPA pages in full bundle mode. I also tested backward compatibility with Vite 7, and it still worked.